### PR TITLE
Set `DEFAULT_BUMP` to `patch`

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,6 +16,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true
+        DEFAULT_BUMP: patch
     - name: Build and push Docker images
       uses: docker/build-push-action@v1.1.0
       with:


### PR DESCRIPTION
Because most PR's will be from Dependabot and that will be changes to dependencies only with no new features or breaking changes (if there is breakage the tests should fail, and we will be notice before merging and bumping).