### PR TITLE
Fix string interpolation

### DIFF
--- a/src/Command/DefaultCommand.php
+++ b/src/Command/DefaultCommand.php
@@ -150,7 +150,7 @@ class DefaultCommand extends Command implements CompletionAwareInterface
             $addresses = [];
 
             if ($output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
-                $output->writeln("<list>${list['description']}</list>");
+                $output->writeln("<list>{$list['description']}</list>");
             }
 
             foreach ($list['select'] as $conf) {


### PR DESCRIPTION
Using `${var}` in strings is deprecated in PHP 8.2, use `{$var}` instead.

See https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated
