### PR TITLE
Remove reviewers from Dependabot configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @arnested

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,24 +7,18 @@ updates:
     time: '04:00'
     timezone: Europe/Copenhagen
   open-pull-requests-limit: 10
-  reviewers:
-  - "arnested"
 - package-ecosystem: docker
   directory: "/"
   schedule:
     interval: daily
     timezone: Europe/Copenhagen
   open-pull-requests-limit: 10
-  reviewers:
-  - "arnested"
 - package-ecosystem: composer
   directory: "/"
   schedule:
     interval: daily
     timezone: Europe/Copenhagen
   open-pull-requests-limit: 10
-  reviewers:
-  - "arnested"
   allow:
   - dependency-type: direct
   - dependency-type: indirect


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
