### PR TITLE
Potential fix for code scanning alert no. 521: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,8 @@ jobs:
 
   dockerfile:
     name: dockerfile
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/spejder/msml/security/code-scanning/521](https://github.com/spejder/msml/security/code-scanning/521)

The problem is best fixed by adding an explicit `permissions` block to restrict the GITHUB_TOKEN permissions for the flagged job. Since the `dockerfile` job, as well as the other jobs, only use `actions/checkout` and analysis tools, they do not require write permissions to the repository, and `contents: read` is sufficient. 

There are two options: add `permissions` at the workflow level to cover all jobs, or add it only to the flagged job. As per the CodeQL report highlighting line 48 in the `dockerfile` job, the minimal fix is adding `permissions` under the `dockerfile` job.

Edit `.github/workflows/build.yml` by adding this block:
```yaml
permissions:
  contents: read
```
directly under `dockerfile:` (after line 48, before `runs-on:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
