### PR TITLE
Potential fix for code scanning alert no. 520: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,8 @@ jobs:
 
   markdown_lint:
     name: Markdown
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/spejder/msml/security/code-scanning/520](https://github.com/spejder/msml/security/code-scanning/520)

The best way to fix this issue is to add a `permissions` block to the `markdown_lint` job to explicitly limit the permissions of the GITHUB_TOKEN. Since this job only checks out repository contents and runs a linter (no write operations), it only needs read access to repository contents. Therefore, the `permissions` block should be added just before the `runs-on` line for the `markdown_lint` job, with `contents: read`. This change will not alter any existing functionality, but it will enhance security by restricting permissions to the minimal set required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
