### PR TITLE
Potential fix for code scanning alert no. 519: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ env:
 jobs:
   review_codestyle:
     name: PHP
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/spejder/msml/security/code-scanning/519](https://github.com/spejder/msml/security/code-scanning/519)

The fix is to add a `permissions` block specifying `contents: read` (the safest minimal permission) to the `review_codestyle` job definition in `.github/workflows/build.yml`. This matches the existing pattern used for the other jobs (`markdown_lint`, `dockerfile`) in this workflow. This change is confined to the job declaration for `review_codestyle`—by inserting a `permissions:` key above `runs-on:`—and does not affect the logic or processes of any steps in the job. No additional imports, definitions, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
